### PR TITLE
build and check {cuda.ml} in separate R sessions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,6 @@ jobs:
       DEBIAN_FRONTEND: 'noninteractive'
 
     steps:
-
       - run: |
           apt-get update -y
           apt-get install -y sudo software-properties-common dialog apt-utils tzdata
@@ -61,17 +60,30 @@ jobs:
         with:
           extra-packages: rcmdcheck
 
-      - name: Install Miniconda
-        run: reticulate::install_miniconda(force = TRUE)
-        shell: Rscript {0}
+      - name: Build {cuda.ml}
+        id: build-pkg
+        run: |
+          cd ..
+          R CMD build cuda.ml
+          ls -a
+          echo "::set-output name=pkg-dir::$(pwd)"
 
-      - uses: r-lib/actions/check-r-package@v1
-        with:
-          error-on: '"error"'
+      - name: Check {cuda.ml} package
+        run: |
+          print(list.files("."))
+          pkg <- list.files(".", pattern = "cuda\\.ml_.*\\.tar\\.gz")
+          stopifnot(length(pkg) == 1)
+
+          reticulate::install_miniconda(force = TRUE)
+
+          rcmdcheck::rcmdcheck(path = pkg[[1]], args = c("--no-manual", "--as-cran"), check_dir="check")
+        shell: Rscript {0}
+        working-directory: ${{ steps.build-pkg.outputs.pkg-dir }}
 
       - name: Show testthat output
         if: ${{ always() }}
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        run: |
+          find check -name 'testthat.Rout*' -type f -exec cat '{}' \; || :
         shell: bash
 
       - name: Upload check results


### PR DESCRIPTION
Fun story: when @dfalbel and I were working on https://github.com/mlverse/cuda.ml/pull/154, at one point when I tried installing {cuda.ml} with the pre-built version of `libcuml`, and then running `ldd libs/cuda.ml.so` from where {cuda.ml} was installed, I saw this type of output:

```
ldd cuda.ml.so
...
        libcuml++.so => /tmp/Rtmp<something>/<something>/libcuml++.so
...
```
which suggested to me the `libcuml++` shared library was not bundled quite correctly with the rest of the {cuda.ml} intallation. But oddly enough, everything in `r-cmd-check`, including the "installed package can be loaded from temporary location" check, came back OK. I later figured out that was only possible because the package installation and the checks were performed within the same R session. If the checks were done in a separate R session from the installation, then the `/tmp/Rtmp<something>/<something>/libcuml++.so` file would not have existed and the r-cmd-check would have surfaced the issue.

Also, it turns out for the linkage of `cuda.ml.so` to the bundled `libcuml++.so` to work in a *relocatable* manner (which is required for the package-loadable-from-temp-location check), `cuda.ml.so` must have its RPATH / RUNPATH set to '[$ORIGIN]'. This type of issue was again something that would have been surfaced if the package installation and r-cmd-check happened in separate R sessions, but would not have been surfaced otherwise.

Signed-off-by: Yitao Li <yitao@rstudio.com>