### PR TITLE
remove default values from some *_bridge functions

### DIFF
--- a/R/elastic_net.R
+++ b/R/elastic_net.R
@@ -158,11 +158,11 @@ cuda_ml_elastic_net.recipe <- function(x, data,
 }
 
 cuda_ml_elastic_net_bridge <- function(processed,
-                                       alpha = 1, l1_ratio = 0.5,
-                                       max_iter = 1000L, tol = 1e-3,
-                                       fit_intercept = TRUE,
-                                       normalize_input = FALSE,
-                                       selection = c("cyclic", "random"),
+                                       alpha, l1_ratio,
+                                       max_iter, tol,
+                                       fit_intercept,
+                                       normalize_input,
+                                       selection,
                                        ...) {
   validate_lm_input(processed)
   elastic_net_validate_alpha(alpha)

--- a/R/lasso.R
+++ b/R/lasso.R
@@ -152,11 +152,11 @@ cuda_ml_lasso.recipe <- function(x, data,
 }
 
 cuda_ml_lasso_bridge <- function(processed,
-                                 alpha = 1,
-                                 max_iter = 1000L, tol = 1e-3,
-                                 fit_intercept = TRUE,
-                                 normalize_input = FALSE,
-                                 selection = c("cyclic", "random"),
+                                 alpha,
+                                 max_iter, tol,
+                                 fit_intercept,
+                                 normalize_input,
+                                 selection,
                                  ...) {
   validate_lm_input(processed)
   lasso_validate_alpha(alpha)

--- a/R/ols.R
+++ b/R/ols.R
@@ -130,9 +130,9 @@ cuda_ml_ols.recipe <- function(x, data,
 }
 
 cuda_ml_ols_bridge <- function(processed,
-                               method = c("svd", "eig", "qr"),
-                               fit_intercept = TRUE,
-                               normalize_input = FALSE,
+                               method,
+                               fit_intercept,
+                               normalize_input,
                                ...) {
   validate_lm_input(processed)
 

--- a/R/ridge.R
+++ b/R/ridge.R
@@ -130,9 +130,9 @@ cuda_ml_ridge.recipe <- function(x, data,
 }
 
 cuda_ml_ridge_bridge <- function(processed,
-                                 alpha = 1,
-                                 fit_intercept = TRUE,
-                                 normalize_input = FALSE,
+                                 alpha,
+                                 fit_intercept,
+                                 normalize_input,
                                  ...) {
   validate_lm_input(processed)
   ridge_validate_alpha(alpha)


### PR DESCRIPTION
Because those are not directly user-facing and are not supposed to have missing args filled in by default values.

Signed-off-by: Yitao Li <yitao@rstudio.com>