### PR TITLE
Remove dead IVFPQ argument

### DIFF
--- a/R/knn.R
+++ b/R/knn.R
@@ -89,8 +89,7 @@ knn_validate_ivfpq_params <- function(
   nlist,
   nprobe,
   m,
-  n_bits,
-  use_precomputed_tables
+  n_bits
 ) {
   stopifnot(
     "`nlist` must be one positive whole number" = is.numeric(nlist) &&
@@ -117,13 +116,7 @@ knn_validate_ivfpq_params <- function(
       n_bits >= 4L &&
       n_bits <= 8L &&
       n_bits == as.integer(n_bits),
-    "`m * n_bits` must be divisible by 8" = (m * n_bits) %% 8L == 0L,
-    "`use_precomputed_tables` must be TRUE or FALSE" = is.logical(
-      use_precomputed_tables
-    ) &&
-      length(use_precomputed_tables) == 1L &&
-      !is.na(use_precomputed_tables),
-    "`use_precomputed_tables = TRUE` is not supported" = !use_precomputed_tables
+    "`m * n_bits` must be divisible by 8" = (m * n_bits) %% 8L == 0L
   )
   invisible(TRUE)
 }
@@ -144,15 +137,13 @@ cuda_ml_knn_algo_ivfpq <- function(
   nlist,
   nprobe,
   m,
-  n_bits,
-  use_precomputed_tables = FALSE
+  n_bits
 ) {
   knn_validate_ivfpq_params(
     nlist,
     nprobe,
     m,
-    n_bits,
-    use_precomputed_tables
+    n_bits
   )
   structure(
     list(
@@ -162,7 +153,7 @@ cuda_ml_knn_algo_ivfpq <- function(
         nprobe = as.integer(nprobe),
         M = as.integer(m),
         n_bits = as.integer(n_bits),
-        usePrecomputedTables = as.logical(use_precomputed_tables)
+        usePrecomputedTables = FALSE
       )
     ),
     class = "cuda_ml_knn_algo"

--- a/man-roxygen/knn-algo-ivfpq.R
+++ b/man-roxygen/knn-algo-ivfpq.R
@@ -1,5 +1,3 @@
 #' @param m Number of subquantizers.
 #' @param n_bits Bits allocated per subquantizer, from 4 to 8. The product of
 #'   \code{m} and \code{n_bits} must be divisible by 8.
-#' @param use_precomputed_tables Must be \code{FALSE}; precomputed tables are
-#'   not supported by the CUVS backend.

--- a/man/cuda_ml_knn_algo_ivfpq.Rd
+++ b/man/cuda_ml_knn_algo_ivfpq.Rd
@@ -4,13 +4,7 @@
 \alias{cuda_ml_knn_algo_ivfpq}
 \title{Build a specification for the "ivfpq" KNN query algorithm.}
 \usage{
-cuda_ml_knn_algo_ivfpq(
-  nlist,
-  nprobe,
-  m,
-  n_bits,
-  use_precomputed_tables = FALSE
-)
+cuda_ml_knn_algo_ivfpq(nlist, nprobe, m, n_bits)
 }
 \arguments{
 \item{nlist}{Number of cells to partition dataset into.}
@@ -22,9 +16,6 @@ neighbor search.}
 
 \item{n_bits}{Bits allocated per subquantizer, from 4 to 8. The product of
 \code{m} and \code{n_bits} must be divisible by 8.}
-
-\item{use_precomputed_tables}{Must be \code{FALSE}; precomputed tables are
-not supported by the CUVS backend.}
 }
 \value{
 An object encapsulating all required parameters of the "ivfpq" KNN

--- a/tests/testthat/test-forward-api.R
+++ b/tests/testthat/test-forward-api.R
@@ -6,6 +6,16 @@ test_that("only current KNN algorithms are exposed", {
   expect_false("cuda_ml_knn_algo_ivfsq" %in% exports)
 })
 
+test_that("IVFPQ exposes only supported parameters", {
+  expect_identical(
+    names(formals(cuda_ml_knn_algo_ivfpq)),
+    c("nlist", "nprobe", "m", "n_bits")
+  )
+
+  specification <- cuda_ml_knn_algo_ivfpq(4, 2, 2, 4)
+  expect_identical(specification$params$usePrecomputedTables, FALSE)
+})
+
 test_that("obsolete random projection and FIL interfaces are absent", {
   exports <- getNamespaceExports("cuda.ml")
 

--- a/tests/testthat/test-forward-api.R
+++ b/tests/testthat/test-forward-api.R
@@ -104,14 +104,6 @@ test_that("KNN parameters fail before backend execution", {
     cuda_ml_knn_algo_ivfpq(4, 2, 2, 9),
     "n_bits"
   )
-  expect_error(
-    cuda_ml_knn_algo_ivfpq(4, 2, 2, 4, NA),
-    "use_precomputed_tables"
-  )
-  expect_error(
-    cuda_ml_knn_algo_ivfpq(4, 2, 2, 4, TRUE),
-    "not supported"
-  )
 
   specification <- cuda_ml_knn_algo_ivfpq(4, 2, 3, 8)
   expect_s3_class(specification, "cuda_ml_knn_algo")


### PR DESCRIPTION
## Summary

Remove the unsupported `use_precomputed_tables` argument from `cuda_ml_knn_algo_ivfpq()` and its generated documentation. The argument could only be `FALSE`, so it did not provide usable behavior with the cuVS backend.

Keep the native `usePrecomputedTables` parameter field and set it unconditionally to `FALSE` for ABI compatibility. Existing validation for `nlist`, `nprobe`, `m`, and `n_bits` is unchanged.

## Impact

The public IVFPQ constructor now accepts exactly `nlist`, `nprobe`, `m`, and `n_bits`. Supported IVFPQ calls retain their existing behavior. Native sources and backend artifacts are unchanged.

## Validation

- Confirmed the new signature regression test failed before implementation because the constructor exposed five formals.
- Ran the focused forward API tests: 64 passed and 2 environment-dependent tests skipped.
- Regenerated documentation with roxygen2 8.0.0 and rendered the generated IVFPQ Rd file successfully.
- Ran `R CMD check --no-manual --as-cran` from a tracked-files-only source export: `Status: OK`.
